### PR TITLE
Fix UIDragger's onDrop event

### DIFF
--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -5,7 +5,7 @@ export const UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 export const UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
 };
 export class UI {
     constructor(group, shape, states = {}, id) {
@@ -197,6 +197,7 @@ export class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
+        this._moveUpID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -208,6 +209,7 @@ export class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
+            this._moveUpID = this.hold(UA.up);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -219,8 +221,9 @@ export class UIDragger extends UIButton {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
+            this.unhold(this._moveUpID);
             if (this.state('moved')) {
-                UI._trigger(this._actions[UA.drop], target, pt, type);
+                UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
         });
@@ -232,10 +235,10 @@ export class UIDragger extends UIButton {
         return this.off(UIPointerActions.uidrag, id);
     }
     onDrop(fn) {
-        return this.on(UIPointerActions.drop, fn);
+        return this.on(UIPointerActions.uidrop, fn);
     }
     offDrop(id) {
-        return this.off(UIPointerActions.drop, id);
+        return this.off(UIPointerActions.uidrop, id);
     }
 }
 //# sourceMappingURL=UI.js.map

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -7907,7 +7907,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
 };
 
 var UI = function () {
@@ -8178,6 +8178,7 @@ var UIDragger = function (_UIButton) {
 
         _this2._draggingID = -1;
         _this2._moveHoldID = -1;
+        _this2._moveUpID = -1;
         if (states.dragging === undefined) _this2._states['dragging'] = false;
         if (states.moved === undefined) _this2._states['moved'] = false;
         if (states.offset === undefined) _this2._states['offset'] = new Pt_1.Pt();
@@ -8186,6 +8187,7 @@ var UIDragger = function (_UIButton) {
             _this2.state('dragging', true);
             _this2.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             _this2._moveHoldID = _this2.hold(UA.move);
+            _this2._moveUpID = _this2.hold(UA.up);
             _this2._draggingID = _this2.on(UA.move, function (t, p) {
                 if (_this2.state('dragging')) {
                     UI._trigger(_this2._actions[UA.uidrag], t, p, UA.uidrag);
@@ -8197,8 +8199,9 @@ var UIDragger = function (_UIButton) {
             _this2.state('dragging', false);
             _this2.off(UA.move, _this2._draggingID);
             _this2.unhold(_this2._moveHoldID);
+            _this2.unhold(_this2._moveUpID);
             if (_this2.state('moved')) {
-                UI._trigger(_this2._actions[UA.drop], target, pt, type);
+                UI._trigger(_this2._actions[UA.uidrop], target, pt, UA.uidrop);
                 _this2.state('moved', false);
             }
         });
@@ -8218,12 +8221,12 @@ var UIDragger = function (_UIButton) {
     }, {
         key: "onDrop",
         value: function onDrop(fn) {
-            return this.on(exports.UIPointerActions.drop, fn);
+            return this.on(exports.UIPointerActions.uidrop, fn);
         }
     }, {
         key: "offDrop",
         value: function offDrop(id) {
-            return this.off(exports.UIPointerActions.drop, id);
+            return this.off(exports.UIPointerActions.uidrop, id);
         }
     }]);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5378,7 +5378,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
 };
 class UI {
     constructor(group, shape, states = {}, id) {
@@ -5572,6 +5572,7 @@ class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
+        this._moveUpID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5583,6 +5584,7 @@ class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
+            this._moveUpID = this.hold(UA.up);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -5594,8 +5596,9 @@ class UIDragger extends UIButton {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
+            this.unhold(this._moveUpID);
             if (this.state('moved')) {
-                UI._trigger(this._actions[UA.drop], target, pt, type);
+                UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
         });
@@ -5607,10 +5610,10 @@ class UIDragger extends UIButton {
         return this.off(exports.UIPointerActions.uidrag, id);
     }
     onDrop(fn) {
-        return this.on(exports.UIPointerActions.drop, fn);
+        return this.on(exports.UIPointerActions.uidrop, fn);
     }
     offDrop(id) {
-        return this.off(exports.UIPointerActions.drop, id);
+        return this.off(exports.UIPointerActions.uidrop, id);
     }
 }
 exports.UIDragger = UIDragger;

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -5378,7 +5378,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
 };
 class UI {
     constructor(group, shape, states = {}, id) {
@@ -5572,6 +5572,7 @@ class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
+        this._moveUpID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5583,6 +5584,7 @@ class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
+            this._moveUpID = this.hold(UA.up);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -5594,8 +5596,9 @@ class UIDragger extends UIButton {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
+            this.unhold(this._moveUpID);
             if (this.state('moved')) {
-                UI._trigger(this._actions[UA.drop], target, pt, type);
+                UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
         });
@@ -5607,10 +5610,10 @@ class UIDragger extends UIButton {
         return this.off(exports.UIPointerActions.uidrag, id);
     }
     onDrop(fn) {
-        return this.on(exports.UIPointerActions.drop, fn);
+        return this.on(exports.UIPointerActions.uidrop, fn);
     }
     offDrop(id) {
-        return this.off(exports.UIPointerActions.drop, id);
+        return this.off(exports.UIPointerActions.uidrop, id);
     }
 }
 exports.UIDragger = UIDragger;


### PR DESCRIPTION
Fixes #63 

@williamngan, I had a closer look and you did re-implement drag/drop in the UIDragger for a reason. Space's drag/drop doesn't work as soon as the mouse becomes faster that the UI repositioning since the space's event happen out of the UI element.

For drag, you correctly separated `drag` and `uidrag`, I've made changes so the same applies to `drop` and the newly added `uidrop`. This fixes 2 things: the double drop event issue that I reported in #63, as well as the missed drop event if you're dropping while moving your mouse fast and the drop happens while the mouse is out of the UI element.

Hope this is good to go, let me know if it needs changes.

PS: I've added a code comment so we can remember why this exists next time ;).