### PR TITLE
Do not emit 'up' on 'drop'

### DIFF
--- a/dist/es2015/Space.js
+++ b/dist/es2015/Space.js
@@ -208,9 +208,12 @@ export class MultiTouchSpace extends Space {
         return false;
     }
     _mouseUp(evt) {
-        this._mouseAction(UIA.up, evt);
-        if (this._dragged)
+        if (this._dragged) {
             this._mouseAction(UIA.drop, evt);
+        }
+        else {
+            this._mouseAction(UIA.up, evt);
+        }
         this._pressed = false;
         this._dragged = false;
         return false;

--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -197,7 +197,7 @@ export class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
-        this._moveUpID = -1;
+        this._moveDropID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -209,7 +209,7 @@ export class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
-            this._moveUpID = this.hold(UA.up);
+            this._moveDropID = this.hold(UA.drop);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -217,11 +217,11 @@ export class UIDragger extends UIButton {
                 }
             });
         });
-        this.on(UA.up, (target, pt, type) => {
+        this.on(UA.drop, (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
-            this.unhold(this._moveUpID);
+            this.unhold(this._moveDropID);
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);

--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -78,7 +78,7 @@ export class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];
@@ -205,7 +205,7 @@ export class UIDragger extends UIButton {
         if (states.offset === undefined)
             this._states['offset'] = new Pt();
         const UA = UIPointerActions;
-        this.on(UA.down, (target, pt, type) => {
+        this.on(UA.drag, (target, pt, type) => {
             this.state('dragging', true);
             this.state('offset', new Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -7979,7 +7979,7 @@ var UI = function () {
         key: "unhold",
         value: function unhold(id) {
             if (id !== undefined) {
-                this._holds = this._holds.splice(id, 1);
+                this._holds.splice(id, 1);
             } else {
                 this._holds = [];
             }
@@ -8186,7 +8186,7 @@ var UIDragger = function (_UIButton) {
         if (states.moved === undefined) _this2._states['moved'] = false;
         if (states.offset === undefined) _this2._states['offset'] = new Pt_1.Pt();
         var UA = exports.UIPointerActions;
-        _this2.on(UA.down, function (target, pt, type) {
+        _this2.on(UA.drag, function (target, pt, type) {
             _this2.state('dragging', true);
             _this2.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             _this2._moveHoldID = _this2.hold(UA.move);

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -7263,8 +7263,11 @@ var MultiTouchSpace = function (_Space) {
     }, {
         key: "_mouseUp",
         value: function _mouseUp(evt) {
-            this._mouseAction(UI_1.UIPointerActions.up, evt);
-            if (this._dragged) this._mouseAction(UI_1.UIPointerActions.drop, evt);
+            if (this._dragged) {
+                this._mouseAction(UI_1.UIPointerActions.drop, evt);
+            } else {
+                this._mouseAction(UI_1.UIPointerActions.up, evt);
+            }
             this._pressed = false;
             this._dragged = false;
             return false;
@@ -8178,7 +8181,7 @@ var UIDragger = function (_UIButton) {
 
         _this2._draggingID = -1;
         _this2._moveHoldID = -1;
-        _this2._moveUpID = -1;
+        _this2._moveDropID = -1;
         if (states.dragging === undefined) _this2._states['dragging'] = false;
         if (states.moved === undefined) _this2._states['moved'] = false;
         if (states.offset === undefined) _this2._states['offset'] = new Pt_1.Pt();
@@ -8187,7 +8190,7 @@ var UIDragger = function (_UIButton) {
             _this2.state('dragging', true);
             _this2.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             _this2._moveHoldID = _this2.hold(UA.move);
-            _this2._moveUpID = _this2.hold(UA.up);
+            _this2._moveDropID = _this2.hold(UA.drop);
             _this2._draggingID = _this2.on(UA.move, function (t, p) {
                 if (_this2.state('dragging')) {
                     UI._trigger(_this2._actions[UA.uidrag], t, p, UA.uidrag);
@@ -8195,11 +8198,11 @@ var UIDragger = function (_UIButton) {
                 }
             });
         });
-        _this2.on(UA.up, function (target, pt, type) {
+        _this2.on(UA.drop, function (target, pt, type) {
             _this2.state('dragging', false);
             _this2.off(UA.move, _this2._draggingID);
             _this2.unhold(_this2._moveHoldID);
-            _this2.unhold(_this2._moveUpID);
+            _this2.unhold(_this2._moveDropID);
             if (_this2.state('moved')) {
                 UI._trigger(_this2._actions[UA.uidrop], target, pt, UA.uidrop);
                 _this2.state('moved', false);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4891,9 +4891,12 @@ class MultiTouchSpace extends Space {
         return false;
     }
     _mouseUp(evt) {
-        this._mouseAction(UI_1.UIPointerActions.up, evt);
-        if (this._dragged)
+        if (this._dragged) {
             this._mouseAction(UI_1.UIPointerActions.drop, evt);
+        }
+        else {
+            this._mouseAction(UI_1.UIPointerActions.up, evt);
+        }
         this._pressed = false;
         this._dragged = false;
         return false;
@@ -5572,7 +5575,7 @@ class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
-        this._moveUpID = -1;
+        this._moveDropID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5584,7 +5587,7 @@ class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
-            this._moveUpID = this.hold(UA.up);
+            this._moveDropID = this.hold(UA.drop);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -5592,11 +5595,11 @@ class UIDragger extends UIButton {
                 }
             });
         });
-        this.on(UA.up, (target, pt, type) => {
+        this.on(UA.drop, (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
-            this.unhold(this._moveUpID);
+            this.unhold(this._moveDropID);
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);

--- a/dist/index.js
+++ b/dist/index.js
@@ -5454,7 +5454,7 @@ class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];
@@ -5583,7 +5583,7 @@ class UIDragger extends UIButton {
         if (states.offset === undefined)
             this._states['offset'] = new Pt_1.Pt();
         const UA = exports.UIPointerActions;
-        this.on(UA.down, (target, pt, type) => {
+        this.on(UA.drag, (target, pt, type) => {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -4891,9 +4891,12 @@ class MultiTouchSpace extends Space {
         return false;
     }
     _mouseUp(evt) {
-        this._mouseAction(UI_1.UIPointerActions.up, evt);
-        if (this._dragged)
+        if (this._dragged) {
             this._mouseAction(UI_1.UIPointerActions.drop, evt);
+        }
+        else {
+            this._mouseAction(UI_1.UIPointerActions.up, evt);
+        }
         this._pressed = false;
         this._dragged = false;
         return false;
@@ -5572,7 +5575,7 @@ class UIDragger extends UIButton {
         super(group, shape, states, id);
         this._draggingID = -1;
         this._moveHoldID = -1;
-        this._moveUpID = -1;
+        this._moveDropID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5584,7 +5587,7 @@ class UIDragger extends UIButton {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);
-            this._moveUpID = this.hold(UA.up);
+            this._moveDropID = this.hold(UA.drop);
             this._draggingID = this.on(UA.move, (t, p) => {
                 if (this.state('dragging')) {
                     UI._trigger(this._actions[UA.uidrag], t, p, UA.uidrag);
@@ -5592,11 +5595,11 @@ class UIDragger extends UIButton {
                 }
             });
         });
-        this.on(UA.up, (target, pt, type) => {
+        this.on(UA.drop, (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this.unhold(this._moveHoldID);
-            this.unhold(this._moveUpID);
+            this.unhold(this._moveDropID);
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -5454,7 +5454,7 @@ class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];
@@ -5583,7 +5583,7 @@ class UIDragger extends UIButton {
         if (states.offset === undefined)
             this._states['offset'] = new Pt_1.Pt();
         const UA = exports.UIPointerActions;
-        this.on(UA.down, (target, pt, type) => {
+        this.on(UA.drag, (target, pt, type) => {
             this.state('dragging', true);
             this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             this._moveHoldID = this.hold(UA.move);

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -439,8 +439,11 @@ export abstract class MultiTouchSpace extends Space {
   * @param evt 
   */
   protected _mouseUp( evt:MouseEvent|TouchEvent ) {
-    this._mouseAction( UIA.up, evt );
-    if (this._dragged) this._mouseAction( UIA.drop, evt );
+    if (this._dragged) {
+      this._mouseAction( UIA.drop, evt );
+    } else {
+      this._mouseAction( UIA.up, evt );
+    }
     this._pressed = false;
     this._dragged = false;
     return false;

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -433,8 +433,8 @@ export class UIDragger extends UIButton {
      * UI refreshes.
      */
 
-     // Handle pointer down and begin dragging
-    this.on( UA.down, (target:UI, pt:PtLike, type:string) => {
+     // Handle pointer drag and begin dragging
+    this.on( UA.drag, (target:UI, pt:PtLike, type:string) => {
       this.state( 'dragging', true );
       this.state( 'offset', new Pt(pt).subtract( target.group[0] ) );
 

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -409,7 +409,7 @@ export class UIDragger extends UIButton {
 
   private _draggingID:number = -1;
   private _moveHoldID:number = -1;
-  private _moveUpID:number = -1;
+  private _moveDropID:number = -1;
 
   /**
    * Create a dragger which has all the states in UIButton, with additional "dragging" (a boolean indicating whether it's currently being dragged) and "offset" (a Pt representing the offset between this UI's position and the pointer's position when dragged) states. (See [`UI.state`](#link)) You may also create a new UIDragger using one of the static helper like [`UI.fromRectangle`](#link) or [`UI.fromCircle`](#link).
@@ -440,7 +440,7 @@ export class UIDragger extends UIButton {
 
       // begin listening for all events after dragging starts
       this._moveHoldID = this.hold( UA.move ); // keep hold of move
-      this._moveUpID = this.hold( UA.up ); // keep hold of up
+      this._moveDropID = this.hold( UA.drop ); // keep hold of drop
       this._draggingID = this.on( UA.move, (t:UI, p:PtLike) => {
         if ( this.state('dragging') ) {
           UI._trigger( this._actions[UA.uidrag], t, p, UA.uidrag );
@@ -449,12 +449,12 @@ export class UIDragger extends UIButton {
       });
     });
 
-    // Handle pointer up and end dragging
-    this.on( UA.up, (target:UI, pt:PtLike, type:string) => {
+    // Handle pointer drop and end dragging
+    this.on( UA.drop, (target:UI, pt:PtLike, type:string) => {
       this.state('dragging', false);
       this.off(UA.move, this._draggingID); // remove 'all' listener
       this.unhold( this._moveHoldID ); // // stop keeping hold of move
-      this.unhold( this._moveUpID ); // // stop keeping hold of up
+      this.unhold( this._moveDropID ); // // stop keeping hold of drop
       if ( this.state('moved') ) {
         UI._trigger( this._actions[UA.uidrop], target, pt, UA.uidrop );
         this.state( 'moved', false );


### PR DESCRIPTION
Closes #66 

@williamngan here you go, I fixed it not at the `UIDragger` level but at the `Space` level since space events "suffered the same fate" 😄. 

Hope it looks good to you. One "major" change is some click event are not emitted anymore. Is there any other place I might not know about that relies on them?