### PR TITLE
add alpha method to forms

### DIFF
--- a/dist/es2015/Canvas.js
+++ b/dist/es2015/Canvas.js
@@ -204,6 +204,7 @@ export class CanvasForm extends VisualForm {
         this._style = {
             fillStyle: "#f03", strokeStyle: "#fff",
             lineWidth: 1, lineJoin: "bevel", lineCap: "butt",
+            globalAlpha: 1
         };
         this._space = space;
         this._space.add({ start: () => {
@@ -226,6 +227,11 @@ export class CanvasForm extends VisualForm {
         if (this._space.hasOffscreen) {
             this._space.ctx.drawImage(this._space.offscreenCanvas, offset[0], offset[1], this._space.width, this._space.height);
         }
+    }
+    alpha(a) {
+        this._ctx.globalAlpha = a;
+        this._style.globalAlpha = a;
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {

--- a/dist/es2015/Dom.js
+++ b/dist/es2015/Dom.js
@@ -202,6 +202,7 @@ export class HTMLForm extends VisualForm {
                 "border-width": "1px",
                 "border-radius": "0",
                 "border-style": "solid",
+                "opacity": 1,
                 "position": "absolute",
                 "top": 0,
                 "left": 0,
@@ -225,6 +226,10 @@ export class HTMLForm extends VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = `${v}${unit}`;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -286,7 +291,7 @@ export class HTMLForm extends VisualForm {
         this._ctx.style = {
             "filled": true, "stroked": true,
             "background": "#f03", "border-color": "#fff",
-            "border-width": "1px"
+            "border-width": "1px", "opacity": 1
         };
         this._font = new Font(14, "sans-serif");
         this._ctx.font = this._font.value;

--- a/dist/es2015/Form.js
+++ b/dist/es2015/Form.js
@@ -33,6 +33,9 @@ export class VisualForm extends Form {
         }
         return this;
     }
+    alpha(a) {
+        return this;
+    }
     fill(c) {
         return this;
     }

--- a/dist/es2015/Svg.js
+++ b/dist/es2015/Svg.js
@@ -70,7 +70,8 @@ export class SVGForm extends VisualForm {
                 "stroke": "#fff",
                 "stroke-width": 1,
                 "stroke-linejoin": "bevel",
-                "stroke-linecap": "sqaure"
+                "stroke-linecap": "sqaure",
+                "opacity": 1,
             },
             font: "11px sans-serif",
             fontSize: 11,
@@ -89,6 +90,10 @@ export class SVGForm extends VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = v;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -149,7 +154,8 @@ export class SVGForm extends VisualForm {
             "fill": "#f03", "stroke": "#fff",
             "stroke-width": 1,
             "stroke-linejoin": "bevel",
-            "stroke-linecap": "sqaure"
+            "stroke-linecap": "sqaure",
+            "opacity": 1,
         };
         this._font = new Font(14, "sans-serif");
         this._ctx.font = this._font.value;

--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -78,7 +78,7 @@ export class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -385,7 +385,8 @@ var CanvasForm = function (_Form_1$VisualForm) {
 
         _this2._style = {
             fillStyle: "#f03", strokeStyle: "#fff",
-            lineWidth: 1, lineJoin: "bevel", lineCap: "butt"
+            lineWidth: 1, lineJoin: "bevel", lineCap: "butt",
+            globalAlpha: 1
         };
         _this2._space = space;
         _this2._space.add({ start: function start() {
@@ -417,6 +418,13 @@ var CanvasForm = function (_Form_1$VisualForm) {
             if (this._space.hasOffscreen) {
                 this._space.ctx.drawImage(this._space.offscreenCanvas, offset[0], offset[1], this._space.width, this._space.height);
             }
+        }
+    }, {
+        key: "alpha",
+        value: function alpha(a) {
+            this._ctx.globalAlpha = a;
+            this._style.globalAlpha = a;
+            return this;
         }
     }, {
         key: "fill",
@@ -2099,6 +2107,7 @@ var HTMLForm = function (_Form_1$VisualForm) {
                 "border-width": "1px",
                 "border-radius": "0",
                 "border-style": "solid",
+                "opacity": 1,
                 "position": "absolute",
                 "top": 0,
                 "left": 0,
@@ -2126,6 +2135,12 @@ var HTMLForm = function (_Form_1$VisualForm) {
 
             if (this._ctx.style[k] === undefined) throw new Error(k + " style property doesn't exist");
             this._ctx.style[k] = "" + v + unit;
+        }
+    }, {
+        key: "alpha",
+        value: function alpha(a) {
+            this.styleTo("opacity", a);
+            return this;
         }
     }, {
         key: "fill",
@@ -2189,7 +2204,7 @@ var HTMLForm = function (_Form_1$VisualForm) {
             this._ctx.style = {
                 "filled": true, "stroked": true,
                 "background": "#f03", "border-color": "#fff",
-                "border-width": "1px"
+                "border-width": "1px", "opacity": 1
             };
             this._font = new Form_1.Font(14, "sans-serif");
             this._ctx.font = this._font.value;
@@ -2473,6 +2488,11 @@ var VisualForm = function (_Form) {
             for (var i = 0, len = groups.length; i < len; i++) {
                 this[shape].apply(this, [groups[i]].concat(rest));
             }
+            return this;
+        }
+    }, {
+        key: "alpha",
+        value: function alpha(a) {
             return this;
         }
     }, {
@@ -7448,7 +7468,8 @@ var SVGForm = function (_Form_1$VisualForm) {
                 "stroke": "#fff",
                 "stroke-width": 1,
                 "stroke-linejoin": "bevel",
-                "stroke-linecap": "sqaure"
+                "stroke-linecap": "sqaure",
+                "opacity": 1
             },
             font: "11px sans-serif",
             fontSize: 11,
@@ -7469,6 +7490,12 @@ var SVGForm = function (_Form_1$VisualForm) {
         value: function styleTo(k, v) {
             if (this._ctx.style[k] === undefined) throw new Error(k + " style property doesn't exist");
             this._ctx.style[k] = v;
+        }
+    }, {
+        key: "alpha",
+        value: function alpha(a) {
+            this.styleTo("opacity", a);
+            return this;
         }
     }, {
         key: "fill",
@@ -7528,7 +7555,8 @@ var SVGForm = function (_Form_1$VisualForm) {
                 "fill": "#f03", "stroke": "#fff",
                 "stroke-width": 1,
                 "stroke-linejoin": "bevel",
-                "stroke-linecap": "sqaure"
+                "stroke-linecap": "sqaure",
+                "opacity": 1
             };
             this._font = new Form_1.Font(14, "sans-serif");
             this._ctx.font = this._font.value;
@@ -7976,7 +8004,7 @@ var UI = function () {
         key: "unhold",
         value: function unhold(id) {
             if (id !== undefined) {
-                this._holds = this._holds.splice(id, 1);
+                this._holds.splice(id, 1);
             } else {
                 this._holds = [];
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -318,6 +318,7 @@ class CanvasForm extends Form_1.VisualForm {
         this._style = {
             fillStyle: "#f03", strokeStyle: "#fff",
             lineWidth: 1, lineJoin: "bevel", lineCap: "butt",
+            globalAlpha: 1
         };
         this._space = space;
         this._space.add({ start: () => {
@@ -340,6 +341,11 @@ class CanvasForm extends Form_1.VisualForm {
         if (this._space.hasOffscreen) {
             this._space.ctx.drawImage(this._space.offscreenCanvas, offset[0], offset[1], this._space.width, this._space.height);
         }
+    }
+    alpha(a) {
+        this._ctx.globalAlpha = a;
+        this._style.globalAlpha = a;
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -1499,6 +1505,7 @@ class HTMLForm extends Form_1.VisualForm {
                 "border-width": "1px",
                 "border-radius": "0",
                 "border-style": "solid",
+                "opacity": 1,
                 "position": "absolute",
                 "top": 0,
                 "left": 0,
@@ -1522,6 +1529,10 @@ class HTMLForm extends Form_1.VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = `${v}${unit}`;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -1583,7 +1594,7 @@ class HTMLForm extends Form_1.VisualForm {
         this._ctx.style = {
             "filled": true, "stroked": true,
             "background": "#f03", "border-color": "#fff",
-            "border-width": "1px"
+            "border-width": "1px", "opacity": 1
         };
         this._font = new Form_1.Font(14, "sans-serif");
         this._ctx.font = this._font.value;
@@ -1783,6 +1794,9 @@ class VisualForm extends Form {
         for (let i = 0, len = groups.length; i < len; i++) {
             this[shape](groups[i], ...rest);
         }
+        return this;
+    }
+    alpha(a) {
         return this;
     }
     fill(c) {
@@ -5016,7 +5030,8 @@ class SVGForm extends Form_1.VisualForm {
                 "stroke": "#fff",
                 "stroke-width": 1,
                 "stroke-linejoin": "bevel",
-                "stroke-linecap": "sqaure"
+                "stroke-linecap": "sqaure",
+                "opacity": 1,
             },
             font: "11px sans-serif",
             fontSize: 11,
@@ -5035,6 +5050,10 @@ class SVGForm extends Form_1.VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = v;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -5095,7 +5114,8 @@ class SVGForm extends Form_1.VisualForm {
             "fill": "#f03", "stroke": "#fff",
             "stroke-width": 1,
             "stroke-linejoin": "bevel",
-            "stroke-linecap": "sqaure"
+            "stroke-linecap": "sqaure",
+            "opacity": 1,
         };
         this._font = new Form_1.Font(14, "sans-serif");
         this._ctx.font = this._font.value;
@@ -5451,7 +5471,7 @@ class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -318,6 +318,7 @@ class CanvasForm extends Form_1.VisualForm {
         this._style = {
             fillStyle: "#f03", strokeStyle: "#fff",
             lineWidth: 1, lineJoin: "bevel", lineCap: "butt",
+            globalAlpha: 1
         };
         this._space = space;
         this._space.add({ start: () => {
@@ -340,6 +341,11 @@ class CanvasForm extends Form_1.VisualForm {
         if (this._space.hasOffscreen) {
             this._space.ctx.drawImage(this._space.offscreenCanvas, offset[0], offset[1], this._space.width, this._space.height);
         }
+    }
+    alpha(a) {
+        this._ctx.globalAlpha = a;
+        this._style.globalAlpha = a;
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -1499,6 +1505,7 @@ class HTMLForm extends Form_1.VisualForm {
                 "border-width": "1px",
                 "border-radius": "0",
                 "border-style": "solid",
+                "opacity": 1,
                 "position": "absolute",
                 "top": 0,
                 "left": 0,
@@ -1522,6 +1529,10 @@ class HTMLForm extends Form_1.VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = `${v}${unit}`;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -1583,7 +1594,7 @@ class HTMLForm extends Form_1.VisualForm {
         this._ctx.style = {
             "filled": true, "stroked": true,
             "background": "#f03", "border-color": "#fff",
-            "border-width": "1px"
+            "border-width": "1px", "opacity": 1
         };
         this._font = new Form_1.Font(14, "sans-serif");
         this._ctx.font = this._font.value;
@@ -1783,6 +1794,9 @@ class VisualForm extends Form {
         for (let i = 0, len = groups.length; i < len; i++) {
             this[shape](groups[i], ...rest);
         }
+        return this;
+    }
+    alpha(a) {
         return this;
     }
     fill(c) {
@@ -5016,7 +5030,8 @@ class SVGForm extends Form_1.VisualForm {
                 "stroke": "#fff",
                 "stroke-width": 1,
                 "stroke-linejoin": "bevel",
-                "stroke-linecap": "sqaure"
+                "stroke-linecap": "sqaure",
+                "opacity": 1,
             },
             font: "11px sans-serif",
             fontSize: 11,
@@ -5035,6 +5050,10 @@ class SVGForm extends Form_1.VisualForm {
         if (this._ctx.style[k] === undefined)
             throw new Error(`${k} style property doesn't exist`);
         this._ctx.style[k] = v;
+    }
+    alpha(a) {
+        this.styleTo("opacity", a);
+        return this;
     }
     fill(c) {
         if (typeof c == "boolean") {
@@ -5095,7 +5114,8 @@ class SVGForm extends Form_1.VisualForm {
             "fill": "#f03", "stroke": "#fff",
             "stroke-width": 1,
             "stroke-linejoin": "bevel",
-            "stroke-linecap": "sqaure"
+            "stroke-linecap": "sqaure",
+            "opacity": 1,
         };
         this._font = new Form_1.Font(14, "sans-serif");
         this._ctx.font = this._font.value;
@@ -5451,7 +5471,7 @@ class UI {
     }
     unhold(id) {
         if (id !== undefined) {
-            this._holds = this._holds.splice(id, 1);
+            this._holds.splice(id, 1);
         }
         else {
             this._holds = [];

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -399,6 +399,7 @@ export class CanvasForm extends VisualForm {
   protected _style = {
     fillStyle: "#f03", strokeStyle:"#fff", 
     lineWidth: 1, lineJoin: "bevel", lineCap: "butt",
+    globalAlpha: 1
   };
   
   
@@ -448,6 +449,18 @@ export class CanvasForm extends VisualForm {
       this._space.ctx.drawImage( 
         this._space.offscreenCanvas, offset[0], offset[1], this._space.width, this._space.height );
       }
+    }
+  
+  
+    /**
+     * Set current alpha value.
+     * @example `form.alpha(0.6)`
+     * @param a alpha value between 0 and 1
+     */
+    alpha( a:number ):this {
+      this._ctx.globalAlpha = a;
+      this._style.globalAlpha = a;
+      return this;
     }
     
     

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -375,6 +375,7 @@ export class HTMLForm extends VisualForm {
       "border-width": "1px",
       "border-radius": "0",
       "border-style": "solid",
+      "opacity": 1,
       "position": "absolute",
       "top": 0,
       "left": 0,
@@ -422,6 +423,17 @@ export class HTMLForm extends VisualForm {
   protected styleTo( k, v, unit:string='' ) { 
     if (this._ctx.style[k] === undefined) throw new Error(`${k} style property doesn't exist`);
     this._ctx.style[k] = `${v}${unit}`; 
+  }
+  
+  
+  /**
+   * Set current alpha value.
+   * @example `form.alpha(0.6)`
+   * @param a alpha value between 0 and 1
+   */
+  alpha( a:number ):this {
+    this.styleTo( "opacity", a );
+    return this;
   }
 
 
@@ -520,7 +532,7 @@ export class HTMLForm extends VisualForm {
     this._ctx.style = {
       "filled": true, "stroked": true,
       "background": "#f03", "border-color": "#fff",
-      "border-width": "1px"
+      "border-width": "1px", "opacity": 1
     };
 
     this._font = new Font( 14, "sans-serif");

--- a/src/Form.ts
+++ b/src/Form.ts
@@ -81,6 +81,15 @@ export abstract class VisualForm extends Form {
   
   
   /**
+   * Set alpha (not implemented here  -- to be implemented in subclasses).
+   * @param a alpha value between 0 and 1
+   */
+  alpha( a:number ):this {
+    return this;
+  }
+  
+  
+  /**
    * Set fill color (not implemented here  -- to be implemented in subclasses).
    * @param c fill color as string or `false` to specify transparent.
    */

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -137,7 +137,8 @@ export class SVGForm extends VisualForm {
       "stroke": "#fff",
       "stroke-width": 1,
       "stroke-linejoin": "bevel",
-      "stroke-linecap": "sqaure"
+      "stroke-linecap": "sqaure",
+      "opacity": 1,
     },
     font: "11px sans-serif",
     fontSize: 11,
@@ -181,6 +182,17 @@ export class SVGForm extends VisualForm {
   styleTo( k, v ) { 
     if (this._ctx.style[k] === undefined) throw new Error(`${k} style property doesn't exist`);
     this._ctx.style[k] = v; 
+  }
+  
+  
+  /**
+   * Set current alpha value.
+   * @example `form.alpha(0.6)`
+   * @param a alpha value between 0 and 1
+   */
+  alpha( a:number ):this {
+    this.styleTo( "opacity", a );
+    return this;
   }
   
 
@@ -272,7 +284,8 @@ export class SVGForm extends VisualForm {
       "fill": "#f03", "stroke": "#fff",
       "stroke-width": 1,
       "stroke-linejoin": "bevel",
-      "stroke-linecap": "sqaure"
+      "stroke-linecap": "sqaure",
+      "opacity": 1,
     };
 
     this._font = new Font( 14, "sans-serif");


### PR DESCRIPTION
Hi @williamngan, this is a small feature proposal. Sorry for pushing a PR without asking first and feel free to close if not in line with your vision for the lib.

I'd like to suggest adding a `.alpha()` method to forms. This is especially useful for images. Most other elements have colors that can be set with an alpha component but it can offer an alternative way to set colors. My use case is images anyway.

I have tested the CanvasForm one but I'm unfamiliar with DOMForm and SVGForm, so it's not tested with those. Just a small CSS addition though so I'm 🤞 that it just works 😬.

Also, my original idea was to add an optional parameter to the `image()` method. This is less generic and not in line with the way you have implemented things so far so I opted out. We could however get from `form.alpha(0.2).image(myImage, new Pt(0, 0)).alpha(1)` to `form.image(myImage, new Pt(0, 0), 0.2)`. This can be useful to avoid setting the global alpha in a way users might not expect. I can add it but I prefer to take your opinion on this first. I'm indifferent at this point.