### PR TITLE
only set drag offset when start dragging

### DIFF
--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -207,9 +207,9 @@ export class UIDragger extends UIButton {
             this._states['offset'] = new Pt();
         const UA = UIPointerActions;
         this.on(UA.drag, (target, pt, type) => {
-            this.state('dragging', true);
-            this.state('offset', new Pt(pt).subtract(target.group[0]));
             if (this._moveHoldID === -1) {
+                this.state('dragging', true);
+                this.state('offset', new Pt(pt).subtract(target.group[0]));
                 this._moveHoldID = this.hold(UA.move);
             }
             if (this._dropHoldID === -1) {

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -8218,9 +8218,9 @@ var UIDragger = function (_UIButton) {
         if (states.offset === undefined) _this2._states['offset'] = new Pt_1.Pt();
         var UA = exports.UIPointerActions;
         _this2.on(UA.drag, function (target, pt, type) {
-            _this2.state('dragging', true);
-            _this2.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             if (_this2._moveHoldID === -1) {
+                _this2.state('dragging', true);
+                _this2.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
                 _this2._moveHoldID = _this2.hold(UA.move);
             }
             if (_this2._dropHoldID === -1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5605,9 +5605,9 @@ class UIDragger extends UIButton {
             this._states['offset'] = new Pt_1.Pt();
         const UA = exports.UIPointerActions;
         this.on(UA.drag, (target, pt, type) => {
-            this.state('dragging', true);
-            this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             if (this._moveHoldID === -1) {
+                this.state('dragging', true);
+                this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
                 this._moveHoldID = this.hold(UA.move);
             }
             if (this._dropHoldID === -1) {

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -5605,9 +5605,9 @@ class UIDragger extends UIButton {
             this._states['offset'] = new Pt_1.Pt();
         const UA = exports.UIPointerActions;
         this.on(UA.drag, (target, pt, type) => {
-            this.state('dragging', true);
-            this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
             if (this._moveHoldID === -1) {
+                this.state('dragging', true);
+                this.state('offset', new Pt_1.Pt(pt).subtract(target.group[0]));
                 this._moveHoldID = this.hold(UA.move);
             }
             if (this._dropHoldID === -1) {

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -436,11 +436,10 @@ export class UIDragger extends UIButton {
 
      // Handle pointer drag and begin dragging
     this.on( UA.drag, (target:UI, pt:PtLike, type:string) => {
-      this.state( 'dragging', true );
-      this.state( 'offset', new Pt(pt).subtract( target.group[0] ) );
-
       // begin listening for all events after dragging starts
       if (this._moveHoldID === -1) {
+        this.state( 'dragging', true );
+        this.state( 'offset', new Pt(pt).subtract( target.group[0] ) );
         this._moveHoldID = this.hold( UA.move ); // keep hold of move
       }
       if (this._dropHoldID === -1) {


### PR DESCRIPTION
Hi @williamngan, found another issue (probably due to my recent changes on the dragger). The drag offset was being set each time drag happens so the offset value was useless making it impossible to drag large objects as it won't drag until the pointer gets out of the object. It's a small fix but it works well in my tests. Happy to iterate if needed. Cheers