### PR TITLE
Fix HTMLSpace text positioning

### DIFF
--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -643,6 +643,17 @@ export class HTMLForm extends VisualForm {
   }
   
   /**
+   * A helper function to set top and left of text DOM context.
+   * @param ctx context to add style to
+   * @param a PtLike object determining the top-left position of the text
+   */
+  static textStyle( ctx:DOMFormContext, pt:PtLike ):DOMFormContext {
+    ctx.style["left"] = pt[0]+"px"; 
+    ctx.style["top"] = pt[1]+"px"; 
+    return ctx;
+  }
+
+  /**
   * A static function to draws a point.
   * @param ctx a context object of HTMLForm
   * @param pt a Pt object or numeric array
@@ -768,13 +779,13 @@ export class HTMLForm extends VisualForm {
     let elem = HTMLSpace.htmlElement( ctx.group, "div", HTMLForm.getID(ctx) );
     
     HTMLSpace.setAttr( elem, {
-      position: 'absolute',
       class: `pts-form pts-text ${ctx.currentClass}`,
       left: pt[0],
       top: pt[1],
     });
     
     elem.textContent = txt;
+    HTMLForm.textStyle( ctx, pt );
     HTMLForm.style( elem, ctx.style );
     
     return elem;

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -643,9 +643,9 @@ export class HTMLForm extends VisualForm {
   }
   
   /**
-   * A helper function to set top and left of text DOM context.
+   * A helper function to set the top and left position styling of text DOM context.
    * @param ctx context to add style to
-   * @param a PtLike object determining the top-left position of the text
+   * @param pt a Pt object or numeric array determining the top-left position of the text
    */
   static textStyle( ctx:DOMFormContext, pt:PtLike ):DOMFormContext {
     ctx.style["left"] = pt[0]+"px"; 

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -778,11 +778,7 @@ export class HTMLForm extends VisualForm {
   static text( ctx:DOMFormContext, pt:PtLike, txt:string ):Element {
     let elem = HTMLSpace.htmlElement( ctx.group, "div", HTMLForm.getID(ctx) );
     
-    HTMLSpace.setAttr( elem, {
-      class: `pts-form pts-text ${ctx.currentClass}`,
-      left: pt[0],
-      top: pt[1],
-    });
+    HTMLSpace.setAttr( elem, { class: `pts-form pts-text ${ctx.currentClass}` });
     
     elem.textContent = txt;
     HTMLForm.textStyle( ctx, pt );


### PR DESCRIPTION
Hello again!

I was playing around with the experimental HTMLSpace and found a bug. Namely, the text function doesn't set the position correctly. It sets 'left' and 'top' as HTML attributes instead of CSS properties and hence doesn't work. I build my patch and tried it out, and it fixed the problem. I tried to be consistent with your code by making a textStyle helper function just as you already have a rectStyle one, but of course feel free to change my implementation.

PS: I love this library and its beautiful documentation, really inspiring!