### PR TITLE
Small bug DOM form fixes

### DIFF
--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -406,7 +406,7 @@ export class HTMLForm extends VisualForm {
     this._space.add( { start: () => {
       this._ctx.group = this._space.element;
       this._ctx.groupID = "pts_dom_"+(HTMLForm.groupID++);
-      this._ctx.style = this._style;
+      this._ctx.style = Object.assign({}, this._style);
       this._ready = true;
     }} );
   }

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -537,11 +537,7 @@ export class HTMLForm extends VisualForm {
   * Reset the context's common styles to this form's styles. This supports using multiple forms on the same canvas context.
   */
   reset():this {
-    for (let k in this._style) {
-      if (this._style.hasOwnProperty(k)) {
-        this._ctx.style[k] = this._style[k];
-      }
-    }
+    this._ctx.style = Object.assign({}, this._style);
 
     this._font = new Font( 14, "sans-serif");
     this._ctx.font = this._font.value;

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -360,28 +360,33 @@ export class HTMLSpace extends DOMSpace {
  */
 export class HTMLForm extends VisualForm {
 
+  /** 
+  * store common styles so that they can be restored to canvas context when using multiple forms. See `reset()`.
+  */
+  protected _style = {
+    "filled": true,
+    "stroked": true,
+    "background": "#f03",
+    "border-color": "#fff",
+    "color": "#000",
+    "border-width": "1px",
+    "border-radius": "0",
+    "border-style": "solid",
+    "opacity": 1,
+    "position": "absolute",
+    "top": 0,
+    "left": 0,
+    "width": 0,
+    "height": 0
+  };
+
   protected _ctx:DOMFormContext = {
     group: null,
     groupID: "pts",
     groupCount: 0,
     currentID: "pts0",
     currentClass: "",
-    style: {
-      "filled": true,
-      "stroked": true,
-      "background": "#f03",
-      "border-color": "#fff",
-      "color": "#000",
-      "border-width": "1px",
-      "border-radius": "0",
-      "border-style": "solid",
-      "opacity": 1,
-      "position": "absolute",
-      "top": 0,
-      "left": 0,
-      "width": 0,
-      "height": 0
-    },
+    style: {},
     font: "11px sans-serif",
     fontSize: 11,
     fontFamily: "sans-serif"
@@ -404,6 +409,7 @@ export class HTMLForm extends VisualForm {
     this._space.add( { start: () => {
       this._ctx.group = this._space.element;
       this._ctx.groupID = "pts_dom_"+(HTMLForm.groupID++);
+      this._ctx.style = this._style;
       this._ready = true;
     }} );
   }
@@ -529,11 +535,11 @@ export class HTMLForm extends VisualForm {
   * Reset the context's common styles to this form's styles. This supports using multiple forms on the same canvas context.
   */
   reset():this {
-    this._ctx.style = {
-      "filled": true, "stroked": true,
-      "background": "#f03", "border-color": "#fff",
-      "border-width": "1px", "opacity": 1
-    };
+    for (let k in this._style) {
+      if (this._style.hasOwnProperty(k)) {
+        this._ctx.style[k] = this._style[k];
+      }
+    }
 
     this._font = new Font( 14, "sans-serif");
     this._ctx.font = this._font.value;

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -387,9 +387,6 @@ export class HTMLForm extends VisualForm {
     currentID: "pts0",
     currentClass: "",
     style: {},
-    font: "11px sans-serif",
-    fontSize: 11,
-    fontFamily: "sans-serif"
   };
 
   static groupID:number = 0;
@@ -539,8 +536,8 @@ export class HTMLForm extends VisualForm {
   reset():this {
     this._ctx.style = Object.assign({}, this._style);
 
-    this._font = new Font( 14, "sans-serif");
-    this._ctx.font = this._font.value;
+    this._font = new Font( 10, "sans-serif");
+    this._ctx.style['font'] = this._font.value;
 
     return this;
   }

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -523,11 +523,13 @@ export class HTMLForm extends VisualForm {
       if (weight) this._font.weight = weight;
       if (style) this._font.style = style;
       if (lineHeight) this._font.lineHeight = lineHeight;
-      this._ctx.font = this._font.value;
-      
+
     } else {
       this._font = sizeOrFont;
     }
+
+    this._ctx.style['font'] = this._font.value;
+
     return this;
   }
 

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -162,7 +162,7 @@ export class SVGForm extends VisualForm {
     this._space.add( { start: () => {
       this._ctx.group = this._space.element;
       this._ctx.groupID = "pts_svg_"+(SVGForm.groupID++);
-      this._ctx.style = this._style;
+      this._ctx.style = Object.assign({}, this._style);
       this._ready = true;
     }} );
   }

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -284,11 +284,7 @@ export class SVGForm extends VisualForm {
   * Reset the context's common styles to this form's styles. This supports using multiple forms in the same space.
   */
   reset():this {
-    for (let k in this._style) {
-      if (this._style.hasOwnProperty(k)) {
-        this._ctx.style[k] = this._style[k];
-      }
-    }
+    this._ctx.style = Object.assign({}, this._style);
 
     this._font = new Font( 14, "sans-serif");
     this._ctx.font = this._font.value;

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -123,6 +123,17 @@ export class SVGSpace extends DOMSpace {
 * You may extend SVGForm to implement your own expressions for SVGSpace. See out the [Space guide](../guide/Space-0500.html) for details.
 */
 export class SVGForm extends VisualForm {
+
+  protected _style = {
+    "filled": true,
+    "stroked": true,
+    "fill": "#f03",
+    "stroke": "#fff",
+    "stroke-width": 1,
+    "stroke-linejoin": "bevel",
+    "stroke-linecap": "sqaure",
+    "opacity": 1
+  };
   
   protected _ctx:DOMFormContext = {
     group: null,
@@ -130,16 +141,7 @@ export class SVGForm extends VisualForm {
     groupCount: 0,
     currentID: "pts0",
     currentClass: "",
-    style: {
-      "filled": true,
-      "stroked": true,
-      "fill": "#f03",
-      "stroke": "#fff",
-      "stroke-width": 1,
-      "stroke-linejoin": "bevel",
-      "stroke-linecap": "sqaure",
-      "opacity": 1,
-    },
+    style: {},
     font: "11px sans-serif",
     fontSize: 11,
     fontFamily: "sans-serif"
@@ -163,6 +165,7 @@ export class SVGForm extends VisualForm {
     this._space.add( { start: () => {
       this._ctx.group = this._space.element;
       this._ctx.groupID = "pts_svg_"+(SVGForm.groupID++);
+      this._ctx.style = this._style;
       this._ready = true;
     }} );
   }
@@ -279,14 +282,11 @@ export class SVGForm extends VisualForm {
   * Reset the context's common styles to this form's styles. This supports using multiple forms in the same space.
   */
   reset():this {
-    this._ctx.style = {
-      "filled": true, "stroked": true,
-      "fill": "#f03", "stroke": "#fff",
-      "stroke-width": 1,
-      "stroke-linejoin": "bevel",
-      "stroke-linecap": "sqaure",
-      "opacity": 1,
-    };
+    for (let k in this._style) {
+      if (this._style.hasOwnProperty(k)) {
+        this._ctx.style[k] = this._style[k];
+      }
+    }
 
     this._font = new Font( 14, "sans-serif");
     this._ctx.font = this._font.value;

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -142,9 +142,6 @@ export class SVGForm extends VisualForm {
     currentID: "pts0",
     currentClass: "",
     style: {},
-    font: "11px sans-serif",
-    fontSize: 11,
-    fontFamily: "sans-serif"
   };
   
   static groupID:number = 0;
@@ -286,8 +283,8 @@ export class SVGForm extends VisualForm {
   reset():this {
     this._ctx.style = Object.assign({}, this._style);
 
-    this._font = new Font( 14, "sans-serif");
-    this._ctx.font = this._font.value;
+    this._font = new Font( 10, "sans-serif");
+    this._ctx.style['font'] = this._font.value;
 
     return this;
   }

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -269,11 +269,13 @@ export class SVGForm extends VisualForm {
       if (weight) this._font.weight = weight;
       if (style) this._font.style = style;
       if (lineHeight) this._font.lineHeight = lineHeight;
-      this._ctx.font = this._font.value;
       
     } else {
       this._font = sizeOrFont;
     }
+
+    this._ctx.style['font'] = this._font.value;
+
     return this;
   }
   

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -115,7 +115,6 @@ export type DOMFormContext = {
   currentID:string,
   currentClass?:string,
   style:object,
-  font:string, fontSize:number, fontFamily:string
 };
 
 


### PR DESCRIPTION
Hi,

These commits should partially fix issues #77 and #78. 

#77: Just as already present in CanvasForm, I made a `_style` attribute in SVG & HTML form for storing the default style, such that it goes back to that default when the `reset()` method is called. Just a little bit cleaner and more consistent with CanvasForm I think. This also fixes the discrepancy of the HTMLForm reset function which caused bugs after resetting. I also made a small attempt at creating a save method which saves the current Form styles as the new default, but wasn't sure of the best way to implement it.

#78: Well, it works... I'm not sure what the `font`, `fontFamily` and `fontSize` of the DOMFormContext are actually supposed to do, I think they can be removed. Also, currently there is by default no font property applied so just the css default is used, and I'm wondering whether I made the best choice. Having a default of 10px sans-serif is good to keep it consistent with CanvasForm (currently there is a non-used of 11px sans-serif in the file [but this should be 10px](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font)). But on the other hand, having the css options of the page apply is also nice to have, in my opinion.

Anyways, I hope this is somewhat helpful. 