### PR TITLE
fix: bail out of drag mode on simple click

### DIFF
--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -199,6 +199,7 @@ export class UIDragger extends UIButton {
         this._draggingID = -1;
         this._moveHoldID = -1;
         this._dropHoldID = -1;
+        this._upHoldID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -215,6 +216,9 @@ export class UIDragger extends UIButton {
             if (this._dropHoldID === -1) {
                 this._dropHoldID = this.hold(UA.drop);
             }
+            if (this._upHoldID === -1) {
+                this._upHoldID = this.hold(UA.up);
+            }
             if (this._draggingID === -1) {
                 this._draggingID = this.on(UA.move, (t, p) => {
                     if (this.state('dragging')) {
@@ -224,7 +228,7 @@ export class UIDragger extends UIButton {
                 });
             }
         });
-        this.on(UA.drop, (target, pt, type) => {
+        const endDrag = (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this._draggingID = -1;
@@ -232,11 +236,15 @@ export class UIDragger extends UIButton {
             this._moveHoldID = -1;
             this.unhold(this._dropHoldID);
             this._dropHoldID = -1;
+            this.unhold(this._upHoldID);
+            this._upHoldID = -1;
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
-        });
+        };
+        this.on(UA.drop, endDrag);
+        this.on(UA.up, endDrag);
     }
     onDrag(fn) {
         return this.on(UIPointerActions.uidrag, fn);

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -8203,6 +8203,7 @@ var UIDragger = function (_UIButton) {
         _this2._draggingID = -1;
         _this2._moveHoldID = -1;
         _this2._dropHoldID = -1;
+        _this2._upHoldID = -1;
         if (states.dragging === undefined) _this2._states['dragging'] = false;
         if (states.moved === undefined) _this2._states['moved'] = false;
         if (states.offset === undefined) _this2._states['offset'] = new Pt_1.Pt();
@@ -8216,6 +8217,9 @@ var UIDragger = function (_UIButton) {
             if (_this2._dropHoldID === -1) {
                 _this2._dropHoldID = _this2.hold(UA.drop);
             }
+            if (_this2._upHoldID === -1) {
+                _this2._upHoldID = _this2.hold(UA.up);
+            }
             if (_this2._draggingID === -1) {
                 _this2._draggingID = _this2.on(UA.move, function (t, p) {
                     if (_this2.state('dragging')) {
@@ -8225,7 +8229,7 @@ var UIDragger = function (_UIButton) {
                 });
             }
         });
-        _this2.on(UA.drop, function (target, pt, type) {
+        var endDrag = function endDrag(target, pt, type) {
             _this2.state('dragging', false);
             _this2.off(UA.move, _this2._draggingID);
             _this2._draggingID = -1;
@@ -8233,11 +8237,15 @@ var UIDragger = function (_UIButton) {
             _this2._moveHoldID = -1;
             _this2.unhold(_this2._dropHoldID);
             _this2._dropHoldID = -1;
+            _this2.unhold(_this2._upHoldID);
+            _this2._upHoldID = -1;
             if (_this2.state('moved')) {
                 UI._trigger(_this2._actions[UA.uidrop], target, pt, UA.uidrop);
                 _this2.state('moved', false);
             }
-        });
+        };
+        _this2.on(UA.drop, endDrag);
+        _this2.on(UA.up, endDrag);
         return _this2;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5585,6 +5585,7 @@ class UIDragger extends UIButton {
         this._draggingID = -1;
         this._moveHoldID = -1;
         this._dropHoldID = -1;
+        this._upHoldID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5601,6 +5602,9 @@ class UIDragger extends UIButton {
             if (this._dropHoldID === -1) {
                 this._dropHoldID = this.hold(UA.drop);
             }
+            if (this._upHoldID === -1) {
+                this._upHoldID = this.hold(UA.up);
+            }
             if (this._draggingID === -1) {
                 this._draggingID = this.on(UA.move, (t, p) => {
                     if (this.state('dragging')) {
@@ -5610,7 +5614,7 @@ class UIDragger extends UIButton {
                 });
             }
         });
-        this.on(UA.drop, (target, pt, type) => {
+        const endDrag = (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this._draggingID = -1;
@@ -5618,11 +5622,15 @@ class UIDragger extends UIButton {
             this._moveHoldID = -1;
             this.unhold(this._dropHoldID);
             this._dropHoldID = -1;
+            this.unhold(this._upHoldID);
+            this._upHoldID = -1;
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
-        });
+        };
+        this.on(UA.drop, endDrag);
+        this.on(UA.up, endDrag);
     }
     onDrag(fn) {
         return this.on(exports.UIPointerActions.uidrag, fn);

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -5585,6 +5585,7 @@ class UIDragger extends UIButton {
         this._draggingID = -1;
         this._moveHoldID = -1;
         this._dropHoldID = -1;
+        this._upHoldID = -1;
         if (states.dragging === undefined)
             this._states['dragging'] = false;
         if (states.moved === undefined)
@@ -5601,6 +5602,9 @@ class UIDragger extends UIButton {
             if (this._dropHoldID === -1) {
                 this._dropHoldID = this.hold(UA.drop);
             }
+            if (this._upHoldID === -1) {
+                this._upHoldID = this.hold(UA.up);
+            }
             if (this._draggingID === -1) {
                 this._draggingID = this.on(UA.move, (t, p) => {
                     if (this.state('dragging')) {
@@ -5610,7 +5614,7 @@ class UIDragger extends UIButton {
                 });
             }
         });
-        this.on(UA.drop, (target, pt, type) => {
+        const endDrag = (target, pt, type) => {
             this.state('dragging', false);
             this.off(UA.move, this._draggingID);
             this._draggingID = -1;
@@ -5618,11 +5622,15 @@ class UIDragger extends UIButton {
             this._moveHoldID = -1;
             this.unhold(this._dropHoldID);
             this._dropHoldID = -1;
+            this.unhold(this._upHoldID);
+            this._upHoldID = -1;
             if (this.state('moved')) {
                 UI._trigger(this._actions[UA.uidrop], target, pt, UA.uidrop);
                 this.state('moved', false);
             }
-        });
+        };
+        this.on(UA.drop, endDrag);
+        this.on(UA.up, endDrag);
     }
     onDrag(fn) {
         return this.on(exports.UIPointerActions.uidrag, fn);


### PR DESCRIPTION
Hi @williamngan,

This is hopefully the last of my series of PRs on UIs. Basically this rights the wrong I introduced with the combination of #67 and #81. Since we wanted to avoid emitting up on uidrop, we tracked drag and drop instead of down and up. But that created the sticky issue, so i reverted to starting dragging on down instead of drag. As a consequence, in the current state if you click a UIDrag, it goes in dragging mode and drop never happens so it's stuck there. With this PR, we're now tracking both drop and up to end drag. drop is your original solution, and up lets us bail out of dragging on simple click. We have to track up since up is not emitted on drop anymore. 

Long story short, I think this is finally the god implementation taking all use-cases into account 😅. It's taken a while to discover all these but hopefully we're covered this time.