### PR TITLE
make Num.cycle smooth

### DIFF
--- a/dist/es2015/Num.js
+++ b/dist/es2015/Num.js
@@ -44,8 +44,8 @@ export class Num {
     static average(pts) {
         return Num.sum(pts).divide(pts.length);
     }
-    static cycle(t) {
-        return Math.pow(Math.sin(Math.PI * t), 2);
+    static cycle(t, method = Shaping.sineInOut) {
+        return method(t > 0.5 ? 2 - t * 2 : t * 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/dist/es2015/Num.js
+++ b/dist/es2015/Num.js
@@ -45,7 +45,7 @@ export class Num {
         return Num.sum(pts).divide(pts.length);
     }
     static cycle(t) {
-        return Math.sin(Math.PI * t);
+        return Math.pow(Math.sin(Math.PI * t), 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -3047,7 +3047,9 @@ var Num = function () {
     }, {
         key: "cycle",
         value: function cycle(t) {
-            return Math.pow(Math.sin(Math.PI * t), 2);
+            var method = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : Shaping.sineInOut;
+
+            return method(t > 0.5 ? 2 - t * 2 : t * 2);
         }
     }, {
         key: "mapToRange",

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -3047,7 +3047,7 @@ var Num = function () {
     }, {
         key: "cycle",
         value: function cycle(t) {
-            return Math.sin(Math.PI * t);
+            return Math.pow(Math.sin(Math.PI * t), 2);
         }
     }, {
         key: "mapToRange",

--- a/dist/index.js
+++ b/dist/index.js
@@ -2173,7 +2173,7 @@ class Num {
         return Num.sum(pts).divide(pts.length);
     }
     static cycle(t) {
-        return Math.sin(Math.PI * t);
+        return Math.pow(Math.sin(Math.PI * t), 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/dist/index.js
+++ b/dist/index.js
@@ -2172,8 +2172,8 @@ class Num {
     static average(pts) {
         return Num.sum(pts).divide(pts.length);
     }
-    static cycle(t) {
-        return Math.pow(Math.sin(Math.PI * t), 2);
+    static cycle(t, method = Shaping.sineInOut) {
+        return method(t > 0.5 ? 2 - t * 2 : t * 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -2173,7 +2173,7 @@ class Num {
         return Num.sum(pts).divide(pts.length);
     }
     static cycle(t) {
-        return Math.sin(Math.PI * t);
+        return Math.pow(Math.sin(Math.PI * t), 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -2172,8 +2172,8 @@ class Num {
     static average(pts) {
         return Num.sum(pts).divide(pts.length);
     }
-    static cycle(t) {
-        return Math.pow(Math.sin(Math.PI * t), 2);
+    static cycle(t, method = Shaping.sineInOut) {
+        return method(t > 0.5 ? 2 - t * 2 : t * 2);
     }
     static mapToRange(n, currA, currB, targetA, targetB) {
         if (currA == currB)

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -126,7 +126,7 @@ export class Num {
    * @return a value between 0 to 1
    */
   static cycle( t:number ):number {
-    return Math.sin( Math.PI * t );
+    return Math.pow(Math.sin( Math.PI * t ), 2);
   }
 
 

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -121,12 +121,13 @@ export class Num {
 
 
   /**
-   * Given a value between 0 to 1, returns a value that cycles between 0 -> 1 -> 0 using sine method.
+   * Given a value between 0 to 1, returns a value that cycles between 0 -> 1 -> 0 using the provided shaping method.
    * @param t a value between 0 to 1
+   * @param method a shaping method. Default to [`Shaping.sineInOut`](#link).
    * @return a value between 0 to 1
    */
-  static cycle( t:number ):number {
-    return Math.pow(Math.sin( Math.PI * t ), 2);
+  static cycle( t:number, method:(t:number) => number=Shaping.sineInOut ):number {
+    return method( t > 0.5 ? 2-t*2 : t*2 );
   }
 
 


### PR DESCRIPTION
Fixes #84 

Hi @williamngan, this is a proposed fix to get smooth cycles as reported by @Yvee1.

@Yvee1 suggested [`( Math.sin( 2 * Math.PI * t ) + 1 ) / 2`](https://www.wolframalpha.com/input/?i=%28sin%28+2+*+PI+*+t+%29+%2B+1+%29+%2F+2) but it would accelerate by a factor of 2 the speed of the animation, which may break the expected behaviour in existing projects.

I researched and [found](https://math.stackexchange.com/questions/121720/ease-in-out-function) [`Math.pow(Math.sin(Math.PI * t), 2)`](https://www.wolframalpha.com/input/?i=%28sin%28PI*x%29%29%5E2) which keeps roughly the same shape with faster acceleration.

Let me know what you think!

--

Funny story, I read about #Hacktoberfest this morning and realised I was one PR away from completing the challenge and my first 3 PRs were all on Pts 😄. So I looked through the issues and liked the small mathematical challenge with this one 😉.