### PR TITLE
Fix/right click

### DIFF
--- a/dist/es2015/Space.js
+++ b/dist/es2015/Space.js
@@ -137,6 +137,7 @@ export class MultiTouchSpace extends Space {
             this.bindCanvas("mouseover", this._mouseOver.bind(this));
             this.bindCanvas("mouseout", this._mouseOut.bind(this));
             this.bindCanvas("mousemove", this._mouseMove.bind(this));
+            this.bindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = true;
         }
         else {
@@ -145,6 +146,7 @@ export class MultiTouchSpace extends Space {
             this.unbindCanvas("mouseover", this._mouseOver.bind(this));
             this.unbindCanvas("mouseout", this._mouseOut.bind(this));
             this.unbindCanvas("mousemove", this._mouseMove.bind(this));
+            this.unbindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = false;
         }
         return this;
@@ -240,6 +242,10 @@ export class MultiTouchSpace extends Space {
         if (this._dragged)
             this._mouseAction(UIA.drop, evt);
         this._dragged = false;
+        return false;
+    }
+    _contextMenu(evt) {
+        this._mouseAction(UIA.contextmenu, evt);
         return false;
     }
     _touchMove(evt) {

--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -5,7 +5,7 @@ export const UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 export const UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", contextmenu: "contextmenu", all: "all"
 };
 export class UI {
     constructor(group, shape, states = {}, id) {
@@ -175,6 +175,12 @@ export class UIButton extends UI {
     }
     offClick(id) {
         return this.off(UIPointerActions.up, id);
+    }
+    onContextMenu(fn) {
+        return this.on(UIPointerActions.contextmenu, fn);
+    }
+    offContextMenu(id) {
+        return this.off(UIPointerActions.contextmenu, id);
     }
     onHover(enter, leave) {
         var ids = [undefined, undefined];

--- a/dist/es2015/UI.js
+++ b/dist/es2015/UI.js
@@ -251,6 +251,7 @@ export class UIDragger extends UIButton {
         };
         this.on(UA.drop, endDrag);
         this.on(UA.up, endDrag);
+        this.on(UA.out, endDrag);
     }
     onDrag(fn) {
         return this.on(UIPointerActions.uidrag, fn);

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -7221,6 +7221,7 @@ var MultiTouchSpace = function (_Space) {
                 this.bindCanvas("mouseover", this._mouseOver.bind(this));
                 this.bindCanvas("mouseout", this._mouseOut.bind(this));
                 this.bindCanvas("mousemove", this._mouseMove.bind(this));
+                this.bindCanvas("contextmenu", this._contextMenu.bind(this));
                 this._hasMouse = true;
             } else {
                 this.unbindCanvas("mousedown", this._mouseDown.bind(this));
@@ -7228,6 +7229,7 @@ var MultiTouchSpace = function (_Space) {
                 this.unbindCanvas("mouseover", this._mouseOver.bind(this));
                 this.unbindCanvas("mouseout", this._mouseOut.bind(this));
                 this.unbindCanvas("mousemove", this._mouseMove.bind(this));
+                this.unbindCanvas("contextmenu", this._contextMenu.bind(this));
                 this._hasMouse = false;
             }
             return this;
@@ -7337,6 +7339,12 @@ var MultiTouchSpace = function (_Space) {
             this._mouseAction(UI_1.UIPointerActions.out, evt);
             if (this._dragged) this._mouseAction(UI_1.UIPointerActions.drop, evt);
             this._dragged = false;
+            return false;
+        }
+    }, {
+        key: "_contextMenu",
+        value: function _contextMenu(evt) {
+            this._mouseAction(UI_1.UIPointerActions.contextmenu, evt);
             return false;
         }
     }, {
@@ -7955,7 +7963,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", contextmenu: "contextmenu", all: "all"
 };
 
 var UI = function () {
@@ -8190,6 +8198,16 @@ var UIButton = function (_UI) {
         key: "offClick",
         value: function offClick(id) {
             return this.off(exports.UIPointerActions.up, id);
+        }
+    }, {
+        key: "onContextMenu",
+        value: function onContextMenu(fn) {
+            return this.on(exports.UIPointerActions.contextmenu, fn);
+        }
+    }, {
+        key: "offContextMenu",
+        value: function offContextMenu(id) {
+            return this.off(exports.UIPointerActions.contextmenu, id);
         }
     }, {
         key: "onHover",

--- a/dist/es5.js
+++ b/dist/es5.js
@@ -8289,6 +8289,7 @@ var UIDragger = function (_UIButton) {
         };
         _this2.on(UA.drop, endDrag);
         _this2.on(UA.up, endDrag);
+        _this2.on(UA.out, endDrag);
         return _this2;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5662,6 +5662,7 @@ class UIDragger extends UIButton {
         };
         this.on(UA.drop, endDrag);
         this.on(UA.up, endDrag);
+        this.on(UA.out, endDrag);
     }
     onDrag(fn) {
         return this.on(exports.UIPointerActions.uidrag, fn);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4844,6 +4844,7 @@ class MultiTouchSpace extends Space {
             this.bindCanvas("mouseover", this._mouseOver.bind(this));
             this.bindCanvas("mouseout", this._mouseOut.bind(this));
             this.bindCanvas("mousemove", this._mouseMove.bind(this));
+            this.bindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = true;
         }
         else {
@@ -4852,6 +4853,7 @@ class MultiTouchSpace extends Space {
             this.unbindCanvas("mouseover", this._mouseOver.bind(this));
             this.unbindCanvas("mouseout", this._mouseOut.bind(this));
             this.unbindCanvas("mousemove", this._mouseMove.bind(this));
+            this.unbindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = false;
         }
         return this;
@@ -4947,6 +4949,10 @@ class MultiTouchSpace extends Space {
         if (this._dragged)
             this._mouseAction(UI_1.UIPointerActions.drop, evt);
         this._dragged = false;
+        return false;
+    }
+    _contextMenu(evt) {
+        this._mouseAction(UI_1.UIPointerActions.contextmenu, evt);
         return false;
     }
     _touchMove(evt) {
@@ -5408,7 +5414,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", contextmenu: "contextmenu", all: "all"
 };
 class UI {
     constructor(group, shape, states = {}, id) {
@@ -5579,6 +5585,12 @@ class UIButton extends UI {
     }
     offClick(id) {
         return this.off(exports.UIPointerActions.up, id);
+    }
+    onContextMenu(fn) {
+        return this.on(exports.UIPointerActions.contextmenu, fn);
+    }
+    offContextMenu(id) {
+        return this.off(exports.UIPointerActions.contextmenu, id);
     }
     onHover(enter, leave) {
         var ids = [undefined, undefined];

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -5662,6 +5662,7 @@ class UIDragger extends UIButton {
         };
         this.on(UA.drop, endDrag);
         this.on(UA.up, endDrag);
+        this.on(UA.out, endDrag);
     }
     onDrag(fn) {
         return this.on(exports.UIPointerActions.uidrag, fn);

--- a/dist/pts.js
+++ b/dist/pts.js
@@ -4844,6 +4844,7 @@ class MultiTouchSpace extends Space {
             this.bindCanvas("mouseover", this._mouseOver.bind(this));
             this.bindCanvas("mouseout", this._mouseOut.bind(this));
             this.bindCanvas("mousemove", this._mouseMove.bind(this));
+            this.bindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = true;
         }
         else {
@@ -4852,6 +4853,7 @@ class MultiTouchSpace extends Space {
             this.unbindCanvas("mouseover", this._mouseOver.bind(this));
             this.unbindCanvas("mouseout", this._mouseOut.bind(this));
             this.unbindCanvas("mousemove", this._mouseMove.bind(this));
+            this.unbindCanvas("contextmenu", this._contextMenu.bind(this));
             this._hasMouse = false;
         }
         return this;
@@ -4947,6 +4949,10 @@ class MultiTouchSpace extends Space {
         if (this._dragged)
             this._mouseAction(UI_1.UIPointerActions.drop, evt);
         this._dragged = false;
+        return false;
+    }
+    _contextMenu(evt) {
+        this._mouseAction(UI_1.UIPointerActions.contextmenu, evt);
         return false;
     }
     _touchMove(evt) {
@@ -5408,7 +5414,7 @@ exports.UIShape = {
     rectangle: "rectangle", circle: "circle", polygon: "polygon", polyline: "polyline", line: "line"
 };
 exports.UIPointerActions = {
-    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+    up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", contextmenu: "contextmenu", all: "all"
 };
 class UI {
     constructor(group, shape, states = {}, id) {
@@ -5579,6 +5585,12 @@ class UIButton extends UI {
     }
     offClick(id) {
         return this.off(exports.UIPointerActions.up, id);
+    }
+    onContextMenu(fn) {
+        return this.on(exports.UIPointerActions.contextmenu, fn);
+    }
+    offContextMenu(id) {
+        return this.off(exports.UIPointerActions.contextmenu, id);
     }
     onHover(enter, leave) {
         var ids = [undefined, undefined];

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -519,7 +519,7 @@ export class CanvasForm extends VisualForm {
     * Activate dashed stroke and set dash style. You can customize the segments and offset.
     * @example `form.dash()`, `form.dash([5, 10])`, `form.dash([5, 5], 5)`, `form.dash(false)`
     * @param segments Dash segments. Defaults to `true` which corresponds to `[5, 5]`. Pass `false` to deactivate dashes. (See [canvas documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash))
-    * @param offset Dash offset. Defaults to 0. (See [canvas documentation]()https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset)
+    * @param offset Dash offset. Defaults to 0. (See [canvas documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineDashOffset)
     */
     dash( segments:PtLike|boolean=true, offset:number=0 ):this {
       if (!segments) {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -334,6 +334,7 @@ export abstract class MultiTouchSpace extends Space {
       this.bindCanvas( "mouseover", this._mouseOver.bind(this) );
       this.bindCanvas( "mouseout", this._mouseOut.bind(this) );
       this.bindCanvas( "mousemove", this._mouseMove.bind(this) );
+      this.bindCanvas( "contextmenu", this._contextMenu.bind(this) );
       this._hasMouse = true;
     } else {
       this.unbindCanvas( "mousedown", this._mouseDown.bind(this) );
@@ -341,6 +342,7 @@ export abstract class MultiTouchSpace extends Space {
       this.unbindCanvas( "mouseover", this._mouseOver.bind(this) );
       this.unbindCanvas( "mouseout", this._mouseOut.bind(this) );
       this.unbindCanvas( "mousemove", this._mouseMove.bind(this) );
+      this.unbindCanvas( "contextmenu", this._contextMenu.bind(this) );
       this._hasMouse = false;
     }
     return this;
@@ -487,6 +489,16 @@ export abstract class MultiTouchSpace extends Space {
     this._mouseAction( UIA.out, evt );
     if (this._dragged) this._mouseAction( UIA.drop, evt );
     this._dragged = false;
+    return false;
+  }
+  
+  
+  /**
+  * ContextMenu handler.
+  * @param evt 
+  */
+  protected _contextMenu( evt:MouseEvent ) {
+    this._mouseAction( UIA.contextmenu, evt );
     return false;
   }
   

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -17,7 +17,7 @@ export const UIShape = {
  * **[Experimental]** A set of string constants to represent different UI event types.
  */
 export const UIPointerActions = {
-  up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", all: "all"
+  up: "up", down: "down", move: "move", drag: "drag", uidrag: "uidrag", drop: "drop", uidrop: "uidrop", over: "over", out: "out", enter: "enter", leave: "leave", contextmenu: "contextmenu", all: "all"
 };
 
 
@@ -356,7 +356,7 @@ export class UIButton extends UI {
   
 
   /**
-   * Add a new click handler. Remember this button will also need to be tracked for events via `UI.track`.
+   * Add a new click handler. Remember this button will also need to be tracked for events via `UI.track`. If you want to track right clicks, you may also consider [`UIButton.onContextMenu`](#link).
    * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    * @returns an id number that refers to this handler, for use in [`UIButton.offClick`](#link) or [`UI.off`](#link).
    */
@@ -372,6 +372,26 @@ export class UIButton extends UI {
    */
   offClick( id:number ):boolean {
     return this.off( UIPointerActions.up, id );
+  }
+
+  
+  /**
+   * Add a new contextmenu handler. `contextmenu` is similar to right click, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event). Remember this button will also need to be tracked for events via `UI.track`.
+   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
+   * @returns an id number that refers to this handler, for use in [`UIButton.offContextMenu`](#link) or [`UI.off`](#link).
+   */
+  onContextMenu( fn:UIHandler ):number {
+    return this.on( UIPointerActions.contextmenu, fn) ;
+  }
+
+
+  /**
+   * Remove an existing contextmenu handler
+   * @param id an ID number returned by [`UIButton.onContextMenu`](#link). If this is not defined, all handlers in this type will be removed.
+   * @returns a boolean indicating whether the handler was removed successfully
+   */
+  offContextMenu( id:number ):boolean {
+    return this.off( UIPointerActions.contextmenu, id );
   }
 
   

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -504,6 +504,7 @@ export class UIDragger extends UIButton {
     };
     this.on( UA.drop, endDrag);
     this.on( UA.up, endDrag);
+    this.on( UA.out, endDrag);
 
   }
 

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -136,7 +136,7 @@ export class UI {
   /**
    * Add an event handler. Remember this UI will also need to be tracked for events via `UI.track`.
    * @param type event type
-   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string )`
+   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    * @returns an id number that reference to this handler, for use in [`UI.off`](#link)
    */
   on( type:string, fn:UIHandler ):number {
@@ -149,7 +149,7 @@ export class UI {
    * Remove an event handler.
    * @param type event type
    * @param which an ID number returned by [`UI.on`](#link). If this is not defined, all handlers in this type will be removed.
-   * @param fn a [`UIHandler`](#link) function: `fn( target:UI, pt:Pt, type:string )`
+   * @param fn a [`UIHandler`](#link) function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    */
   off( type:string, which?:number ):boolean {
     if (!this._actions[type]) return false;
@@ -357,7 +357,7 @@ export class UIButton extends UI {
 
   /**
    * Add a new click handler. Remember this button will also need to be tracked for events via `UI.track`.
-   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string )`
+   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    * @returns an id number that refers to this handler, for use in [`UIButton.offClick`](#link) or [`UI.off`](#link).
    */
   onClick( fn:UIHandler ):number {
@@ -377,8 +377,8 @@ export class UIButton extends UI {
   
   /**
    * Add handlers for hover events. Remember this button will also need to be tracked for events via `UI.track`.
-   * @param enter an optional [`UIHandler`](#link) function to handle when pointer enters hover. Eg, `fn( target:UI, pt:Pt, type:string )`
-   * @param leave an optional [`UIHandler`](#link) function to handle when pointer exits hover. Eg, `fn( target:UI, pt:Pt, type:string )`
+   * @param enter an optional [`UIHandler`](#link) function to handle when pointer enters hover. Eg, `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
+   * @param leave an optional [`UIHandler`](#link) function to handle when pointer exits hover. Eg, `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    * @returns id numbers that refer to enter/leave handlers, for use in [`UIButton.offHover`](#link) or [`UI.off`](#link).
    */
   onHover( enter?:UIHandler, leave?:UIHandler ):number[] {
@@ -490,7 +490,7 @@ export class UIDragger extends UIButton {
 
   /**
    * Add a new drag handler. Remember this button will also need to be tracked for events via `UI.track`.
-   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string )`. You can access the states "dragging" and "offset" (See [`UI.state`](#link)) in the callback.
+   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`. You can access the states "dragging" and "offset" (See [`UI.state`](#link)) in the callback.
    * @returns an id number that refers to this handler, for use in [`UIDragger.offDrag`](#link) or [`UI.off`](#link).
    */
   onDrag( fn:UIHandler ):number {
@@ -510,7 +510,7 @@ export class UIDragger extends UIButton {
 
   /**
    * Add a new drop handler. Remember this button will also need to be tracked for events via `UI.track`.
-   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string )`
+   * @param fn a [`UIHandler`](#link) callback function: `fn( target:UI, pt:Pt, type:string, evt:MouseEvent )`
    * @returns an id number that refers to this handler, for use in [`UIDragger.offDrop`](#link) or [`UI.off`](#link).
    */
   onDrop( fn:UIHandler ):number {


### PR DESCRIPTION
Hi @williamngan,

I have come across a small issue. Left click and right click behaviour is slightly different. Left click is emitted after `mousedown` then `mouseup` events, while `contextmenu` (the equivalent of right click) is emitted after `mousedown` only. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event).

Due to this, we can't really use `onClick` to track right clicks as the `up` event may not happen. E.g. an element higher in the tree catches `contextmenu` and takes focus, which results in an `out` event in the canvas before `up` happens. To make matter worse, this is not consistent across browser and the implementation details of events handling in browsers seem to affect what happens first. 🤷‍♂️  

I have added a dedicated handler `onContextMenu` which is similar to `onClick` to tackle this issue. I thought it was better to leave `onClick` unchanged from the perspective of left vs right click as it is consistent with other events such as drag / drop / etc. and would just work for an application which prevents `contextmenu` events.

Happy to take any feedback and iterate on this based on your thoughts and assessment of the issue.

Cheers.

PS: I've corrected some docs as well, bear with me for mixing that in.