### PR TITLE
Seed the random generator

### DIFF
--- a/src/Create.ts
+++ b/src/Create.ts
@@ -23,9 +23,9 @@ export class Create {
   static distributeRandom( bound:Bound, count:number, dimensions:number=2 ):Group {
     let pts = new Group();
     for (let i=0; i<count; i++) {
-      let p = [ bound.x + Math.random()*bound.width ];
-      if (dimensions>1) p.push( bound.y + Math.random()*bound.height, );
-      if (dimensions>2) p.push( bound.z + Math.random()*bound.depth );
+      let p = [ bound.x + Num.random()*bound.width ];
+      if (dimensions>1) p.push( bound.y + Num.random()*bound.height, );
+      if (dimensions>2) p.push( bound.z + Num.random()*bound.depth );
       pts.push( new Pt( p ) );
     }
     return pts;
@@ -117,7 +117,7 @@ export class Create {
    * @param columns Optional column count to generate 2D noise
    */
   static noisePts( pts:PtIterable, dx=0.01, dy=0.01, rows=0, columns=0 ):Group {
-    let seed = Math.random();
+    let seed = Num.random();
     let g = new Group();
     let i = 0;
     for (let p of pts) {

--- a/src/Num.ts
+++ b/src/Num.ts
@@ -5,10 +5,14 @@ import { Curve } from "./Op";
 import { Pt, Group } from "./Pt";
 import { Vec, Mat } from "./LinearAlgebra";
 import {PtLike, GroupLike, PtLikeIterable, PtIterable} from "./Types";
+
+import generator from './uheprng'
+
 /**
  * Num class provides static helper functions for basic numeric operations.
  */
 export class Num {
+  static generator: any;
 
   /**
    * Check if two numbers are equal or almost equal within a threshold.
@@ -163,6 +167,25 @@ export class Num {
     let min = Math.min(targetA, targetB);
     let max = Math.max(targetA, targetB);
     return Num.normalizeValue(n, currA, currB) * (max - min) + min;
+  }
+
+  /**
+   * Seed the pseudorandom generator.
+   * @param seed seed string
+   */
+  static seed(seed: string): void {
+    this.generator = generator(seed);
+  }
+
+  /**
+   * Return a random number between 0 and 1 from a seed,
+   * if the seed is not defined it uses Math.random
+   * @returns a number between 0 and 1
+   */
+  static random(): number {
+      return this.generator 
+          ? this.generator.random()
+          : Math.random();
   }
 }
 

--- a/src/Pt.ts
+++ b/src/Pt.ts
@@ -39,7 +39,7 @@ export class Pt extends Float32Array implements IPt, Iterable<number> {
     if (defaultValue) p.fill( defaultValue );
     if (randomize) {
       for (let i=0, len=p.length; i<len; i++) {
-        p[i] = p[i]*Math.random();
+        p[i] = p[i]*Num.random();
       }
     }
     return new Pt( p );

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,5 +1,6 @@
 /*! Source code licensed under Apache License 2.0. Copyright © 2017-current William Ngan and contributors. (https://github.com/williamngan/pts) */
 
+import { Num } from "./Num";
 import {Group, Pt} from "./Pt";
 import {WarningType, PtLikeIterable} from "./Types";
 
@@ -173,7 +174,7 @@ export class Util {
    */
   static randomInt( range:number, start:number=0 ) {
     Util.warn("Util.randomInt is deprecated. Please use `Num.randomRange`");
-    return Math.floor( Math.random()*range ) + start;
+    return Math.floor( Num.random()*range ) + start;
   }
 
 

--- a/src/_module.ts
+++ b/src/_module.ts
@@ -14,5 +14,6 @@ export * from "./Typography";
 export * from "./Physics";
 export * from "./Play";
 export * from "./UI";
+export * from "./Image";
 
 

--- a/src/test/Num.spec.ts
+++ b/src/test/Num.spec.ts
@@ -44,6 +44,34 @@ describe('Num: ', function() {
       let p = Num.average( [new Pt(1,3,5,7), new Pt(2,3,8,8), new Pt(5,10,14,21), new Pt(0, 0, 1, 0)] );
       assert.isTrue( p.equals( new Pt(2, 4, 7, 9) ) );
     });
+
+    it('can seed the random function', function () {
+      const a = Num.random()
+      const b = Num.random()
+
+      assert.notEqual(a, b, "Not seeded uses Math.random")
+
+      Num.seed('42')
+      const c = Num.random()
+
+      Num.seed('foo')
+      const f = Num.random()
+      assert.notEqual(c, f, "different seed")
+
+      Num.seed('42')
+      const d = Num.random()
+
+      assert.equal(c, d, "same seed")
+
+      const e = Num.random()
+      assert.notEqual(d, e, "same seed, a second request")
+
+      assert.isTrue(a >= 0 && a < 1)
+      assert.isTrue(b >= 0 && b < 1)
+      assert.isTrue(c >= 0 && c < 1)
+      assert.isTrue(d >= 0 && d < 1)
+      assert.isTrue(e >= 0 && e < 1)
+    })
   });
 
 

--- a/src/uheprng.ts
+++ b/src/uheprng.ts
@@ -1,0 +1,149 @@
+'use strict';
+/* This code has been written by Steve Gibson and can be found here:
+ *
+ * https://www.grc.com/otg/uheprng.htm
+ * 
+ * The code has been converted to typescript and unused functions have 
+ * been removed
+ */
+
+/*	============================================================================
+                                    Gibson Research Corporation
+                UHEPRNG - Ultra High Entropy Pseudo-Random Number Generator
+    ============================================================================
+    LICENSE AND COPYRIGHT:  THIS CODE IS HEREBY RELEASED INTO THE PUBLIC DOMAIN
+    Gibson Research Corporation releases and disclaims ALL RIGHTS AND TITLE IN
+    THIS CODE OR ANY DERIVATIVES. Anyone may be freely use it for any purpose.
+    ============================================================================
+    This is GRC's cryptographically strong PRNG (pseudo-random number generator)
+    for JavaScript. It is driven by 1536 bits of entropy, stored in an array of
+    48, 32-bit JavaScript variables.  Since many applications of this generator,
+    including ours with the "Off The Grid" Latin Square generator, may require
+    the deteriministic re-generation of a sequence of PRNs, this PRNG's initial
+    entropic state can be read and written as a static whole, and incrementally
+    evolved by pouring new source entropy into the generator's internal state.
+    ----------------------------------------------------------------------------
+    ENDLESS THANKS are due Johannes Baagoe for his careful development of highly
+    robust JavaScript implementations of JS PRNGs.  This work was based upon his
+    JavaScript "Alea" PRNG which is based upon the extremely robust Multiply-
+    With-Carry (MWC) PRNG invented by George Marsaglia. MWC Algorithm References:
+    http://www.GRC.com/otg/Marsaglia_PRNGs.pdf
+    http://www.GRC.com/otg/Marsaglia_MWC_Generators.pdf
+    ----------------------------------------------------------------------------
+    The quality of this algorithm's pseudo-random numbers have been verified by
+    multiple independent researchers. It handily passes the fermilab.ch tests as
+    well as the "diehard" and "dieharder" test suites.  For individuals wishing
+    to further verify the quality of this algorithm's pseudo-random numbers, a
+    256-megabyte file of this algorithm's output may be downloaded from GRC.com,
+    and a Microsoft Windows scripting host (WSH) version of this algorithm may be
+    downloaded and run from the Windows command prompt to generate unique files
+    of any size:
+    The Fermilab "ENT" tests: http://fourmilab.ch/random/
+    The 256-megabyte sample PRN file at GRC: https://www.GRC.com/otg/uheprng.bin
+    The Windows scripting host version: https://www.GRC.com/otg/wsh-uheprng.js
+    ----------------------------------------------------------------------------
+    Qualifying MWC multipliers are: 187884, 686118, 898134, 1104375, 1250205,
+    1460910 and 1768863. (We use the largest one that's < 2^21)
+    ============================================================================ 
+*/
+
+/*	============================================================================
+    This is based upon Johannes Baagoe's carefully designed and efficient hash
+    function for use with JavaScript.  It has a proven "avalanche" effect such
+    that every bit of the input affects every bit of the output 50% of the time,
+    which is good.	See: http://baagoe.com/en/RandomMusings/hash/avalanche.xhtml
+    ============================================================================
+*/
+function Mash() {
+    var n = 0xefc8249d;
+    var mash = function (data?: string) {
+        if (data) {
+            data = data.toString();
+            for (var i = 0; i < data.length; i++) {
+                n += data.charCodeAt(i);
+                var h = 0.02519603282416938 * n;
+                n = h >>> 0;
+                h -= n;
+                h *= n;
+                n = h >>> 0;
+                h -= n;
+                n += h * 0x100000000; // 2^32
+            }
+            return (n >>> 0) * 2.3283064365386963e-10; // 2^-32
+        } else n = 0xefc8249d;
+    };
+    return mash;
+}
+
+export default function(seed: string) {
+    var o = 48; // set the 'order' number of ENTROPY-holding 32-bit values
+    var c = 1; // init the 'carry' used by the multiply-with-carry (MWC) algorithm
+    var p = o; // init the 'phase' (max-1) of the intermediate variable pointer
+    var s = new Array(o); // declare our intermediate variables array
+    var i: number,
+        j: number,
+        k = 0; // general purpose locals
+
+    // when our "uheprng" is initially invoked our PRNG state is initialized from the
+    // browser's own local PRNG. This is okay since although its generator might not
+    // be wonderful, it's useful for establishing large startup entropy for our usage.
+    var mash = Mash(); // get a pointer to our high-performance "Mash" hash
+    for (i = 0; i < o; i++) s[i] = mash(Math.random().toString()); // fill the array with initial mash hash values
+
+    // if we want to provide a deterministic startup context for our PRNG,
+    // but without directly setting the internal state variables, this allows
+    // us to initialize the mash hash and PRNG's internal state before providing
+    // some hashing input
+    function initState() {
+        mash(); // pass a null arg to force mash hash to init
+        for (i = 0; i < o; i++) s[i] = mash(' '); // fill the array with initial mash hash values
+        c = 1; // init our multiply-with-carry carry
+        p = o; // init our phase
+    }
+
+    // this EXPORTED "clean string" function removes leading and trailing spaces and non-printing
+    // control characters, including any embedded carriage-return (CR) and line-feed (LF) characters,
+    // from any string it is handed. this is also used by the 'hashstring' function (below) to help
+    // users always obtain the same EFFECTIVE uheprng seeding key.
+    function cleanString(inStr: string) {
+        inStr = inStr.replace(/(^\s*)|(\s*$)/gi, ''); // remove any/all leading spaces
+        inStr = inStr.replace(/[\x00-\x1F]/gi, ''); // remove any/all control characters
+        inStr = inStr.replace(/\n /, '\n'); // remove any/all trailing spaces
+        return inStr; // return the cleaned up result
+    }
+
+    // this EXPORTED "hash string" function hashes the provided character string after first removing
+    // any leading or trailing spaces and ignoring any embedded carriage returns (CR) or Line Feeds (LF)
+    function hashString(inStr: string) {
+        inStr = cleanString(inStr);
+        mash(inStr); // use the string to evolve the 'mash' state
+        for (i = 0; i < inStr.length; i++) {
+            // scan through the characters in our string
+            k = inStr.charCodeAt(i); // get the character code at the location
+            for (j = 0; j < o; j++) {
+                // 	"mash" it into the UHEPRNG state
+                s[j] -= mash(k.toString());
+                if (s[j] < 0) s[j] += 1;
+            }
+        }
+    }
+
+    initState();
+    hashString(seed);
+
+    return {
+        /**
+         * this (not anymore) PRIVATE (internal access only) function is the heart of the multiply-with-carry
+         * (MWC) PRNG algorithm. When called it returns a pseudo-random number in the form of a
+         * 32-bit JavaScript fraction (0.0 to <1.0) it is a PRIVATE function used by the default
+         * [0-1] return function, and by the random 'string(n)' function which returns 'n'
+         * characters from 33 to 126.
+         * @returns a number between 0.0 and 1.0
+         */
+        random() {
+            if (++p >= o) p = 0;
+            var t = 1768863 * s[p] + c * 2.3283064365386963e-10; // 2^-32
+            return (s[p] = t - (c = t | 0));
+        }
+    };
+}


### PR DESCRIPTION
As Javascript does not to allow to seed the random generator I think that Pts could provide a seeded pseudo-random generator so _random_ numbers can be stable between runs of a script.

The function `Num.random` is supposed to replace `Math.number` in the code base so every use of random number can be consistent with the seed (e.g. `Create.distributeRandom` and similar). The implementation should not get in the way of people that don't care about this property and it uses `Math.random` when not seeded.

I noticed that you are not using any external dependencies but I decided to submit the PR anyway to gauge your interest about this feature before looking around for a suitable algorithm.