### PR TITLE
Removed pt.abs() call from gradient method

### DIFF
--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -625,9 +625,6 @@ export class CanvasForm extends VisualForm {
       }
 
       return ( area1:GroupLike, area2?:GroupLike ) => {
-        area1 = area1.map( a => a.abs() );
-        if (area2) area2.map( a => a.abs() );
-
         let grad = area2 
           ? this._ctx.createRadialGradient( area1[0][0], area1[0][1], area1[1][0], area2[0][0], area2[0][1], area2[1][0] )
           : this._ctx.createLinearGradient( area1[0][0], area1[0][1], area1[1][0], area1[1][1] );


### PR DESCRIPTION
This is an attempt to fix [radial gradient behavior for gradients that have a negative center `Pt`](https://github.com/williamngan/pts/issues/195), outside the bounds of the canvas.

**Note:** This PR essentially just removes two lines of code. While it appears to fix my issue, I have a feeling that the call to `pt.abs()` may be important for other reasons outside of my use case. 