### PR TITLE
fix: infinite recursion in Pt constructor

### DIFF
--- a/src/Pt.ts
+++ b/src/Pt.ts
@@ -19,12 +19,14 @@ export class Pt extends Float32Array implements IPt, Iterable<number> {
    * @example `new Pt()`, `new Pt(1,2,3,4,5)`, `new Pt([1,2])`, `new Pt({x:0, y:1})`, `new Pt(pt)`
    * @param args a list of numeric parameters, an array of numbers, or an object with {x,y,z,w} properties
    */
-  constructor(...args) {
+  constructor(...args: Array<number|number[]|IPt|Float32Array>) {
+    let params;
     if (args.length === 1 && typeof args[0] == "number") {
-      super( args[0] ); // init with the TypedArray's length. Needed this in order to make ".map", ".slice" etc work.
+      params = args[0]; // init with the TypedArray's length. Needed this in order to make ".map", ".slice" etc work.
     } else {
-      super( (args.length>0) ? Util.getArgs(args) : [0,0] );
+      params = (args.length>0) ? Util.getArgs(args) : [0,0];
     }    
+    super( params );
   }
 
 


### PR DESCRIPTION
### Goals

This PR should fix the infinite recursion happening with `react-pts-canvas` (https://github.com/williamngan/react-pts-canvas/issues/94). It applies the fix suggested at https://github.com/pixijs/pixijs/pull/9093. The issue seems to be caused by calling **super conditionally**, therefore I collect the params for `super` and call it only once at the end.

How I tested the fix:

1. cloned the latest `react-pts-canvas`
2. cloned the latest `pts`
3. applied the fix in `pts`, then ran `npm run build`
4. ran `npm i` in `react-pts-canvas`, copied over the `dist` from build into `node_modules/pts`, then ran `npm run build`
5. ran `npm i` in the `/example` at `react-pts-canvas`, copied `dist` into `example/node_modules/pts`, then ran `npm start`

### Further thoughts

I think `pts` would be simpler to maintain if using a mono repo for the core-lib (this repo) and all derivates (e.g. react). This would also be an opportunity to provide a consistent wording for the packages, e.g. `@pts/core`, `@pts/react`, etc. But those are just thoughts that I just wanted to share. 